### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sisl #
 
 [![Build Status](https://travis-ci.org/zerothi/sisl.svg?branch=master)](https://travis-ci.org/zerothi/sisl)
-[![DOI for citation](https://zenodo.org/badge/doi/10.5281/zenodo.597181.svg)](http://dx.doi.org/10.5281/zenodo.597181)
+[![DOI for citation](https://zenodo.org/badge/doi/10.5281/zenodo.597181.svg)](https://doi.org/10.5281/zenodo.597181)
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 [![Join the chat at https://gitter.im/sisl-tool/Lobby](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/sisl-tool/Lobby)
 <!--- [![Documentation on RTD](https://readthedocs.org/projects/docs/badge/?version=latest)](http://sisl.readthedocs.io/en/latest/) -->
@@ -271,7 +271,7 @@ Links to external and internal sites.
 [sisl-api]: https://zerothi.github.io/sisl
 [issue]: https://github.com/zerothi/sisl/issues
 [tbtrans]: https://launchpad.net/siesta
-[doi]: http://dx.doi.org/10.5281/zenodo.597181
+[doi]: https://doi.org/10.5281/zenodo.597181
 [pr]: https://github.com/zerothi/sisl/pulls
 [lgpl]: http://www.gnu.org/licenses/lgpl.html
 [ase]: https://wiki.fysik.dtu.dk/ase/

--- a/docs/cite.rst
+++ b/docs/cite.rst
@@ -65,4 +65,4 @@ When using sisl as tight-binding setup for Hamiltonians and dynamical matrices f
 
 
 .. |zenodo| image:: https://zenodo.org/badge/doi/10.5281/zenodo.597181.svg
-.. _zenodo: http://dx.doi.org/10.5281/zenodo.597181
+.. _zenodo: https://doi.org/10.5281/zenodo.597181

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,7 +127,7 @@ Indices
 .. _donate: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=NGNU2AA3JXX94&lc=DK&item_name=Papior%2dCodes&item_number=codes&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted
 
 .. |zenodo| image:: https://zenodo.org/badge/doi/10.5281/zenodo.597181.svg
-.. _zenodo: http://dx.doi.org/10.5281/zenodo.597181
+.. _zenodo: https://doi.org/10.5281/zenodo.597181
 
 .. |gitter| image:: https://img.shields.io/gitter/room/nwjs/nw.js.svg
 .. _gitter: https://gitter.im/sisl-tool/Lobby


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!